### PR TITLE
setdisplay() need using media ?

### DIFF
--- a/pi.ipynb
+++ b/pi.ipynb
@@ -1021,7 +1021,8 @@
    },
    "outputs": [],
    "source": [
-    "using ValidatedNumerics"
+    "using ValidatedNumerics",
+    "using Media"
    ]
   },
   {

--- a/pi.ipynb
+++ b/pi.ipynb
@@ -1022,7 +1022,6 @@
    "outputs": [],
    "source": [
     "using ValidatedNumerics",
-    "using Media"
    ]
   },
   {
@@ -1044,7 +1043,7 @@
     }
    ],
    "source": [
-    "setdisplay(:standard)  # abbreviated display of intervals"
+    "setformat(:standard)  # abbreviated display of intervals"
    ]
   },
   {

--- a/pi.ipynb
+++ b/pi.ipynb
@@ -1021,7 +1021,7 @@
    },
    "outputs": [],
    "source": [
-    "using ValidatedNumerics",
+    "using ValidatedNumerics"
    ]
   },
   {


### PR DESCRIPTION
Hello !

Im new with Julia ! Tried to marathon all your examples until i got this 
```
julia> setdisplay(:full)
ERROR: UndefVarError: setdisplay not defined
```
i found out in Julia documentation that setdisplay() is in Media

`julia> Pkg.add("Media")`

```
julia> setdisplay(:standard)
ERROR: MethodError: no method matching setdisplay(::Symbol)
Closest candidates are:
  setdisplay(::Any, ::Any) at /Users/AHILALY/.julia/v0.5/Media/src/system.jl:98
```
am i missing something ?
